### PR TITLE
Feat: Product details with Domain mapped

### DIFF
--- a/OnlineStoreTCA/.swiftlint.yml
+++ b/OnlineStoreTCA/.swiftlint.yml
@@ -44,6 +44,8 @@ disabled_rules:
   - type_contents_order
   - unused_capture_list
   - vertical_whitespace_between_cases
+  - let_var_whitespace
+  - trailing_whitespace
 
 # Configurations
 attributes:
@@ -51,6 +53,8 @@ attributes:
     - "@ConfigurationElement"
     - "@OptionGroup"
     - "@RuleConfigurationDescriptionBuilder"
+  always_on_same_line:
+    - "@Dependency"
 balanced_xctest_lifecycle: &unit_test_configuration
   test_parent_classes:
     - SwiftLintTestCase
@@ -80,7 +84,7 @@ redundant_type_annotation:
   consider_default_literal_types_redundant: true
 single_test_class: *unit_test_configuration
 trailing_comma:
-  mandatory_comma: true
+  mandatory_comma: false
 type_body_length: 400
 unneeded_override:
   affect_initializers: true
@@ -88,26 +92,3 @@ unused_import:
   always_keep_imports:
     - SwiftSyntaxBuilder # we can't detect uses of string interpolation of swift syntax nodes
     - SwiftLintFramework # now that this is a wrapper around other modules, don't treat as unused
-
-# Custom rules
-custom_rules:
-  rule_id:
-    included: Source/SwiftLintBuiltInRules/Rules/.+/\w+\.swift
-    name: Rule ID
-    message: Rule IDs must be all lowercase, snake case and not end with `rule`
-    regex: ^\s+identifier:\s*("\w+_rule"|"\S*[^a-z_]\S*")
-    severity: error
-  fatal_error:
-    name: Fatal Error
-    excluded: "Tests/*"
-    message: Prefer using `queuedFatalError` over `fatalError` to avoid leaking compiler host machine paths.
-    regex: \bfatalError\b
-    match_kinds:
-      - identifier
-    severity: error
-  rule_test_function:
-    included: Tests/SwiftLintFrameworkTests/RulesTests.swift
-    name: Rule Test Function
-    message: Rule Test Function mustn't end with `rule`
-    regex: func\s*test\w+(r|R)ule\(\)
-    severity: error

--- a/OnlineStoreTCA/OnlineStoreTCA.xcodeproj/project.pbxproj
+++ b/OnlineStoreTCA/OnlineStoreTCA.xcodeproj/project.pbxproj
@@ -16,6 +16,9 @@
 		154C46002CBDC829002E453F /* OnlineStoreTCAUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 154C45FF2CBDC829002E453F /* OnlineStoreTCAUITestsLaunchTests.swift */; };
 		154C46112CBDCC37002E453F /* ComposableArchitecture in Frameworks */ = {isa = PBXBuildFile; productRef = 154C46102CBDCC37002E453F /* ComposableArchitecture */; };
 		154C46172CBF2E11002E453F /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = 154C46162CBF2E11002E453F /* .swiftlint.yml */; };
+		15B743302CC196B300C2B411 /* Product.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15B7432F2CC196B300C2B411 /* Product.swift */; };
+		15B743322CC197C100C2B411 /* ProductDomain.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15B743312CC197C100C2B411 /* ProductDomain.swift */; };
+		15B743342CC1984B00C2B411 /* ProductDetailsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15B743332CC1984B00C2B411 /* ProductDetailsView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -48,6 +51,9 @@
 		154C45FD2CBDC829002E453F /* OnlineStoreTCAUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnlineStoreTCAUITests.swift; sourceTree = "<group>"; };
 		154C45FF2CBDC829002E453F /* OnlineStoreTCAUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnlineStoreTCAUITestsLaunchTests.swift; sourceTree = "<group>"; };
 		154C46162CBF2E11002E453F /* .swiftlint.yml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
+		15B7432F2CC196B300C2B411 /* Product.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Product.swift; sourceTree = "<group>"; };
+		15B743312CC197C100C2B411 /* ProductDomain.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductDomain.swift; sourceTree = "<group>"; };
+		15B743332CC1984B00C2B411 /* ProductDetailsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductDetailsView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -146,8 +152,27 @@
 		154C460D2CBDC8CE002E453F /* Scenes */ = {
 			isa = PBXGroup;
 			children = (
+				15B7432D2CC1969D00C2B411 /* ProductList */,
 			);
 			path = Scenes;
+			sourceTree = "<group>";
+		};
+		15B7432D2CC1969D00C2B411 /* ProductList */ = {
+			isa = PBXGroup;
+			children = (
+				15B7432E2CC196A600C2B411 /* Product */,
+			);
+			path = ProductList;
+			sourceTree = "<group>";
+		};
+		15B7432E2CC196A600C2B411 /* Product */ = {
+			isa = PBXGroup;
+			children = (
+				15B7432F2CC196B300C2B411 /* Product.swift */,
+				15B743312CC197C100C2B411 /* ProductDomain.swift */,
+				15B743332CC1984B00C2B411 /* ProductDetailsView.swift */,
+			);
+			path = Product;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -311,6 +336,9 @@
 			files = (
 				154C45E42CBDC825002E453F /* ContentView.swift in Sources */,
 				154C45E22CBDC825002E453F /* OnlineStoreTCAApp.swift in Sources */,
+				15B743302CC196B300C2B411 /* Product.swift in Sources */,
+				15B743322CC197C100C2B411 /* ProductDomain.swift in Sources */,
+				15B743342CC1984B00C2B411 /* ProductDetailsView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/OnlineStoreTCA/OnlineStoreTCA/Scenes/ProductList/Product/Product.swift
+++ b/OnlineStoreTCA/OnlineStoreTCA/Scenes/ProductList/Product/Product.swift
@@ -1,0 +1,68 @@
+//
+//  Product.swift
+//  OnlineStoreTCA
+//
+//  Created by Gustavo Soares on 17/10/24.
+//
+
+import Foundation
+
+struct Product: Equatable, Identifiable {
+    let id: Int
+    let title: String
+    let currency: Double
+    let description: String
+    let category: String
+    let imageString: String
+}
+
+extension Product: Decodable {
+    enum CodingKeys: String, CodingKey {
+        case id, title, currency, description, category, imageString
+    }
+    
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.id = try container.decode(Int.self, forKey: .id)
+        self.title = try container.decode(String.self, forKey: .title)
+        self.currency = try container.decode(Double.self, forKey: .currency)
+        self.description = try container.decode(String.self, forKey: .description)
+        self.category = try container.decode(String.self, forKey: .category)
+        self.imageString = try container.decode(String.self, forKey: .imageString)
+    }
+}
+
+#if DEBUG
+// swiftlint:disable line_length
+extension Product {
+    static var fixture: [Product] {
+        [
+            .init(
+                id: 1,
+                title: "Mens Casual Premium Slim Fit T-Shirts",
+                currency: 22.3,
+                description: "Slim-fitting style, contrast raglan long sleeve, three-button henley placket, light weight & soft fabric for breathable and comfortable wearing. And Solid stitched shirts with round neck made for durability and a great fit for casual fashion wear and diehard baseball fans. The Henley style round neckline includes a three-button placket.",
+                category: "men's clothing",
+                imageString: "https://fakestoreapi.com/img/71-3HjGNDUL._AC_SY879._SX._UX._SY._UY_.jpg"
+            ),
+            .init(
+                id: 2,
+                title: "Fjallraven - Foldsack No. 1 Backpack, Fits 15 Laptops",
+                currency: 109.95,
+                description: "Your perfect pack for everyday use and walks in the forest. Stash your laptop (up to 15 inches) in the padded sleeve, your everyday",
+                category: "men's clothing",
+                imageString: "https://fakestoreapi.com/img/81fPKd-2AYL._AC_SL1500_.jpg"
+            ),
+            .init(
+                id: 3,
+                title: "Mens Cotton Jacket",
+                currency: 55.99,
+                description: "Great outerwear jackets for Spring/Autumn/Winter, suitable for many occasions, such as working, hiking, camping, mountain/rock climbing, cycling, traveling or other outdoors. Good gift choice for you or your family member. A warm hearted love to Father, husband or son in this thanksgiving or Christmas Day.",
+                category: "men's clothing",
+                imageString: "https://fakestoreapi.com/img/71li-ujtlUL._AC_UX679_.jpg"
+            )
+        ]
+    }
+}
+// swiftlint: enable line_length
+#endif

--- a/OnlineStoreTCA/OnlineStoreTCA/Scenes/ProductList/Product/ProductDetailsView.swift
+++ b/OnlineStoreTCA/OnlineStoreTCA/Scenes/ProductList/Product/ProductDetailsView.swift
@@ -1,0 +1,52 @@
+//
+//  ProductDetailsView.swift
+//  OnlineStoreTCA
+//
+//  Created by Gustavo Soares on 17/10/24.
+//
+
+import ComposableArchitecture
+import SwiftUI
+
+struct ProductDetailsView: View {
+    let store: StoreOf<ProductDomain>
+    
+    var body: some View {
+        WithPerceptionTracking {
+            VStack {
+                AsyncImage(url: URL(string: store.product.imageString)) { image in
+                    image
+                        .resizable()
+                        .aspectRatio(contentMode: .fit)
+                        .frame(height: 300)
+                } placeholder: {
+                    ProgressView()
+                        .frame(height: 300)
+                }
+                VStack(alignment: .leading) {
+                    Text(store.product.title)
+                    HStack {
+                        Text("$\(store.product.currency.description)")
+                            .fontWeight(.bold)
+                        Spacer()
+                    }
+                }
+                .font(.system(size: 20))
+            }
+            .padding(20)
+        }
+    }
+}
+
+#Preview {
+    ProductDetailsView(
+        store: Store(
+            initialState: ProductDomain.State(
+                id: UUID(),
+                product: Product.fixture[0]
+            ),
+            reducer: { ProductDomain() }
+        )
+    )
+    .previewLayout(.fixed(width: 300, height: 300))
+}

--- a/OnlineStoreTCA/OnlineStoreTCA/Scenes/ProductList/Product/ProductDomain.swift
+++ b/OnlineStoreTCA/OnlineStoreTCA/Scenes/ProductList/Product/ProductDomain.swift
@@ -1,0 +1,18 @@
+//
+//  ProductDomain.swift
+//  OnlineStoreTCA
+//
+//  Created by Gustavo Soares on 17/10/24.
+//
+
+import ComposableArchitecture
+import Foundation
+
+@Reducer
+struct ProductDomain {
+    @ObservableState
+    struct State: Equatable, Identifiable {
+        let id: UUID
+        let product: Product
+    }
+}


### PR DESCRIPTION
#### What does this PR do?

- Removes some additional checks from Swiftlint.
- Updates the TCA version to 1.16.0 in order to avoid some warning issues related to using iOS 18.
- Maps product domain that will be used with it related dependencies.

#### What are the relevant requirements?
Nothing specific.

#### Any background you want to provide?
None.

#### Screenshots

| ProductDetailsView preview |
| --- | 
| ![Screenshot 2024-11-14 at 15 07 03](https://github.com/user-attachments/assets/598d8de3-abbc-4b07-8643-89ac10370b9c) |

#### Checklist:
- [ ] Were unit tests added?
- [ ] Documentation is correct — Check "README.md"
